### PR TITLE
Make git describe match short tags

### DIFF
--- a/util/makeversion.sh
+++ b/util/makeversion.sh
@@ -44,7 +44,7 @@ elif [ $# != 0 ];then
 fi
 
 # Get the git repository version number
-REPO=$(git describe --dirty --always)
+REPO=$(git describe --dirty --always --tags)
 
 # Get the build time stamp
 WHEN=$(date +"%Y-%m-%d %H:%M:%S")

--- a/util/makeversion.sh
+++ b/util/makeversion.sh
@@ -44,7 +44,7 @@ elif [ $# != 0 ];then
 fi
 
 # Get the git repository version number
-REPO=$(git describe --dirty --always --tags)
+REPO=$(git describe --tags --always --dirty --broken)
 
 # Get the build time stamp
 WHEN=$(date +"%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
The code @wolframroesler wrote was missing `--tags` to match non-annotated tags.