### PR TITLE
Usage cleanup & select statement fix

### DIFF
--- a/src/pptrees.cc
+++ b/src/pptrees.cc
@@ -188,6 +188,7 @@ struct opt_pptrees : public Pass {
 		log("\n");
 		log("	-mapping <string>\n");
 		log("		mapping strategy (default: behavioral).\n");
+		log("		valid options: behavioral, GTECH, sky130_fd_sc_hd, sky130_fd_sc_hs\n");
 		log("\n");
 
 	}

--- a/src/pptrees.cc
+++ b/src/pptrees.cc
@@ -184,7 +184,10 @@ struct opt_pptrees : public Pass {
 		log("\n");
 		log("	opt_pptrees [options] [selection]\n");
 		log("\n");
-		log("This pass uses the synth_opt_adders tool to optimize adders\n");
+		log("This pass uses the synth_opt_adders tool to optimize adders according to transforms specified by verilog attributes\n");
+		log("	e.g. assign test = a + (* pptrees_alu, pptrees_base=\"brent-kung\" *) b;\n");
+		log("default base = ripple-carry, default transforms = none\n");
+		log("please see plugin demo directory for examples\n");
 		log("\n");
 		log("	-mapping <string>\n");
 		log("		mapping strategy (default: behavioral).\n");

--- a/src/pptrees.cc
+++ b/src/pptrees.cc
@@ -223,12 +223,11 @@ struct opt_pptrees : public Pass {
 	// Save attributes of $add cells before they are removed by alumacc
 	dict<std::string, dict<RTLIL::IdString, RTLIL::Const>> saved_attributes = save_attributes(design);
 
-	// Run alumacc pass
-	Pass::call(design, "alumacc");
-
 	// Iterate through all selected modules
 	for (RTLIL::Module *mod : design->selected_modules())
 	{
+		// Run alumacc pass
+		Pass::call_on_module(design, mod, "alumacc");
 		// Skip modules that contain processes
 		if (mod->has_processes_warn() ) {
 			log("Skipping module %s as it contains processes.\n", log_id(mod));

--- a/src/pptrees.cc
+++ b/src/pptrees.cc
@@ -12,7 +12,6 @@
 #include <cerrno>
 #include <sstream>
 #include <climits>
-//#include <Python.h>
 
 USING_YOSYS_NAMESPACE
 
@@ -210,9 +209,11 @@ struct opt_pptrees : public Pass {
         size_t argidx;
         for (argidx = 1; argidx < args.size(); argidx++) {
             std::string arg = args[argidx];
-		if (arg == "-mapping" && argidx+1 < args.size()) {
-			mapping = args[++argidx]; //super fragile; do this better
-		}
+			if (arg == "-mapping" && argidx+1 < args.size()) {
+				mapping = args[++argidx];
+				continue;
+			}
+			break;
         }
         
         extra_args(args, argidx, design);

--- a/src/pptrees.cc
+++ b/src/pptrees.cc
@@ -269,9 +269,9 @@ struct opt_pptrees : public Pass {
 				std::string pptrees_dir = python_tree(width, start, transforms, mapping);
 
 				// Select and techmap this $alu cell
-				Pass::call(design, stringf("select a:src=%s",cell->get_src_attribute().c_str()));
-				Pass::call(design, stringf("techmap -map %s/pptrees_alu.v %%", pptrees_dir.c_str()));
-				Pass::call(design, "select *");
+				RTLIL::Selection s(false);
+				s.select(mod, cell);
+				Pass::call_on_selection(design, s, stringf("techmap -map %s/pptrees_alu.v %%", pptrees_dir.c_str()));
 
 			}
                 }


### PR DESCRIPTION
minor changes to ensure the pass only runs on selected modules, clarify usage in help statement, and handle argument parsing according to the same pattern as other yosys passes